### PR TITLE
Lyrics

### DIFF
--- a/src/downloader.odin
+++ b/src/downloader.odin
@@ -29,13 +29,7 @@ LyricsResponse :: struct {
 // > "Artist - Title"
 // > "Title"
 // See: https://lrclib.net/docs.
-guess_search_opts :: proc(
-	title: string,
-	allocator := context.temp_allocator,
-) -> (
-	opts: [2]fx.Request_Query_Param,
-	opts_count: int,
-) {
+guess_search_opts :: proc(title: string) -> (opts: [2]fx.Request_Query_Param, opts_count: int) {
 	// Literally every dash I can find; https://www.compart.com/en/unicode/category/Pd.
 	DASHES :: [?]rune {
 		'-',
@@ -112,7 +106,7 @@ download_lyrics :: proc() {
 		duration_mem: [8]u8
 		duration_str := strconv.itoa(duration_mem[:], duration)
 
-		res := fx.get(
+		res, ok := fx.get(
 			"https://lrclib.net/api/get",
 			{
 				{"title", player.current_track.audio_clip.tags.title},
@@ -122,7 +116,7 @@ download_lyrics :: proc() {
 			},
 		)
 
-		if res.status == 0 {
+		if !ok {
 			show_alert({}, "Network Error", "Check your internet connection and try again", 2)
 			return
 		}
@@ -146,10 +140,10 @@ download_lyrics :: proc() {
 	}
 
 	opts, opts_count := guess_search_opts(player.current_track.name)
-	res := fx.get("https://lrclib.net/api/search", opts[:opts_count])
+	res, ok := fx.get("https://lrclib.net/api/search", opts[:opts_count])
 
 
-	if res.status == 0 {
+	if !ok {
 		show_alert({}, "Network Error", "Check your internet connection and try again", 2)
 		return
 	}

--- a/src/downloader.odin
+++ b/src/downloader.odin
@@ -3,21 +3,21 @@ package main
 import "fx"
 
 import "core:encoding/json"
-import "core:unicode/utf8"
 import "core:fmt"
 import "core:os"
 import "core:path/filepath"
 import "core:strconv"
 import "core:strings"
+import "core:unicode/utf8"
 
 LyricsResponse :: struct {
-	id: int `json:"id"`,
-	trackName: string `json:"trackName"`,
-	artistName: string `json:"artistName"`,
-	albumName: string `json:"albumName"`,
-	duration: int `json:"duration"`,
+	id:           int `json:"id"`,
+	trackName:    string `json:"trackName"`,
+	artistName:   string `json:"artistName"`,
+	albumName:    string `json:"albumName"`,
+	duration:     f32 `json:"duration"`,
 	instrumental: bool `json:"instrumental"`,
-	plainLyrics: string `json:"plainLyrics"`,
+	plainLyrics:  string `json:"plainLyrics"`,
 	syncedLyrics: Maybe(string) `json:"syncedLyrics"`,
 }
 
@@ -37,16 +37,18 @@ download_lyrics :: proc() {
 	has_required_metadata := len(title) > 0 && len(artist) > 0 && len(album) > 0 && duration > 0
 
 	if track != nil && has_required_metadata {
-		artist_enc := url_encode(artist)
-		title_enc := url_encode(title)
-		album_enc := url_encode(album)
 		duration_mem: [8]u8
 		duration_str := strconv.itoa(duration_mem[:], duration)
 
-		url := fmt.tprintf("https://lrclib.net/api/get?artist_name=%s&track_name=%s&album_name=%s&duration=%s",
-			artist_enc, title_enc, album_enc, duration_str)
-
-		res := fx.get(url)
+		res := fx.get(
+			"https://lrclib.net/api/get",
+			{
+				{"title", player.current_track.audio_clip.tags.title},
+				{"artist_name", player.current_track.audio_clip.tags.artist},
+				{"album", player.current_track.audio_clip.tags.album},
+				{"duration", strconv.itoa(duration_mem[:], duration)},
+			},
+		)
 
 		if res.status == 0 {
 			show_alert({}, "Network Error", "Check your internet connection and try again", 2)
@@ -57,7 +59,8 @@ download_lyrics :: proc() {
 
 		if res.status == 200 {
 			if lyrics_response, ok := parse_single_lyrics_response(string(res.data)); ok {
-				if synced_lyrics, has_lyrics := lyrics_response.syncedLyrics.?; has_lyrics && len(synced_lyrics) > 0 {
+				if synced_lyrics, has_lyrics := lyrics_response.syncedLyrics.?;
+				   has_lyrics && len(synced_lyrics) > 0 {
 					track.lyrics = load_lyrics_from_string(synced_lyrics)
 					player.current_track.lyrics = track.lyrics
 
@@ -70,10 +73,7 @@ download_lyrics :: proc() {
 		}
 	}
 
-	url := fmt.tprintf("https://lrclib.net/api/search?q=%s", url_encode(player.current_track.name))
-
-	fmt.println(url)
-	res := fx.get(url)
+	res := fx.get("https://lrclib.net/api/search", {{"q", player.current_track.name}})
 
 
 	if res.status == 0 {
@@ -90,8 +90,9 @@ download_lyrics :: proc() {
 			best_duration_diff := max(int)
 
 			for &result in results {
-				if synced_lyrics, has_lyrics := result.syncedLyrics.?; has_lyrics && len(synced_lyrics) > 0 {
-					duration_diff := abs(result.duration - current_duration)
+				if synced_lyrics, has_lyrics := result.syncedLyrics.?;
+				   has_lyrics && len(synced_lyrics) > 0 {
+					duration_diff := abs(int(result.duration) - current_duration)
 					if duration_diff < best_duration_diff {
 						best_duration_diff = duration_diff
 						best_match = &result
@@ -116,7 +117,12 @@ download_lyrics :: proc() {
 					return
 				}
 			} else {
-				show_alert({}, "No Synced Lyrics Available", "No synced lyrics are available for this song", 2)
+				show_alert(
+					{},
+					"No Synced Lyrics Available",
+					"No synced lyrics are available for this song",
+					2,
+				)
 				return
 			}
 		}
@@ -145,113 +151,6 @@ parse_search_lyrics_response :: proc(json_data: string) -> ([]LyricsResponse, bo
 	}
 
 	return results, true
-}
-
-url_encode :: proc(s: string) -> string {
-	builder := strings.builder_make()
-	defer strings.builder_destroy(&builder)
-
-	for r in s {
-		switch r {
-		case ' ':
-			strings.write_string(&builder, "%20")
-		case '!':
-			strings.write_string(&builder, "%21")
-		case '"':
-			strings.write_string(&builder, "%22")
-		case '#':
-			strings.write_string(&builder, "%23")
-		case '$':
-			strings.write_string(&builder, "%24")
-		case '%':
-			strings.write_string(&builder, "%25")
-		case '&':
-			strings.write_string(&builder, "%26")
-		case '\'':
-			strings.write_string(&builder, "%27")
-		case '(':
-			strings.write_string(&builder, "%28")
-		case ')':
-			strings.write_string(&builder, "%29")
-		case '*':
-			strings.write_string(&builder, "%2A")
-		case '+':
-			strings.write_string(&builder, "%2B")
-		case ',':
-			strings.write_string(&builder, "%2C")
-		case '/':
-			strings.write_string(&builder, "%2F")
-		case ':':
-			strings.write_string(&builder, "%3A")
-		case ';':
-			strings.write_string(&builder, "%3B")
-		case '<':
-			strings.write_string(&builder, "%3C")
-		case '=':
-			strings.write_string(&builder, "%3D")
-		case '>':
-			strings.write_string(&builder, "%3E")
-		case '?':
-			strings.write_string(&builder, "%3F")
-		case '@':
-			strings.write_string(&builder, "%40")
-		case '[':
-			strings.write_string(&builder, "%5B")
-		case '\\':
-			strings.write_string(&builder, "%5C")
-		case ']':
-			strings.write_string(&builder, "%5D")
-		case '^':
-			strings.write_string(&builder, "%5E")
-		case '`':
-			strings.write_string(&builder, "%60")
-		case '{':
-			strings.write_string(&builder, "%7B")
-		case '|':
-			strings.write_string(&builder, "%7C")
-		case '}':
-			strings.write_string(&builder, "%7D")
-		case '~':
-			strings.write_string(&builder, "%7E")
-		// Turkish characters
-		case 'ç':
-			strings.write_string(&builder, "%C3%A7")
-		case 'Ç':
-			strings.write_string(&builder, "%C3%87")
-		case 'ğ':
-			strings.write_string(&builder, "%C4%9F")
-		case 'Ğ':
-			strings.write_string(&builder, "%C4%9E")
-		case 'ı':
-			strings.write_string(&builder, "%C4%B1")
-		case 'İ':
-			strings.write_string(&builder, "%C4%B0")
-		case 'ö':
-			strings.write_string(&builder, "%C3%B6")
-		case 'Ö':
-			strings.write_string(&builder, "%C3%96")
-		case 'ş':
-			strings.write_string(&builder, "%C5%9F")
-		case 'Ş':
-			strings.write_string(&builder, "%C5%9E")
-		case 'ü':
-			strings.write_string(&builder, "%C3%BC")
-		case 'Ü':
-			strings.write_string(&builder, "%C3%9C")
-		case:
-			if r >= 0x80 || r < 0x20 {
-				temp_str := utf8.runes_to_string({r}, context.temp_allocator)
-				temp_bytes := transmute([]u8)temp_str
-				for byte in temp_bytes {
-					strings.write_string(&builder, fmt.tprintf("%%%02X", byte))
-				}
-			} else {
-				strings.write_rune(&builder, r)
-			}
-		}
-	}
-
-	return strings.clone(strings.to_string(builder), context.temp_allocator)
 }
 
 save_lyrics_as_lrc :: proc(track: ^Track, lyrics_content: string) {

--- a/src/fx/http.odin
+++ b/src/fx/http.odin
@@ -1,5 +1,10 @@
 package fx
 
+import "base:runtime"
+import "core:net"
+import "core:slice"
+import "core:strings"
+
 import win "core:sys/windows"
 
 WINHTTP_ACCESS_TYPE_DEFAULT_PROXY :: 0
@@ -14,19 +19,19 @@ HINTERNET :: rawptr
 
 URL_COMPONENTS :: struct {
 	dwStructSize:      win.DWORD,
-	lpszScheme:        ^u16,
+	lpszScheme:        [^]u16,
 	dwSchemeLength:    win.DWORD,
 	nScheme:           i32,
-	lpszHostName:      ^u16,
+	lpszHostName:      [^]u16,
 	dwHostNameLength:  win.DWORD,
 	nPort:             u16,
-	lpszUserName:      ^u16,
+	lpszUserName:      [^]u16,
 	dwUserNameLength:  win.DWORD,
-	lpszPassword:      ^u16,
+	lpszPassword:      [^]u16,
 	dwPasswordLength:  win.DWORD,
-	lpszUrlPath:       ^u16,
+	lpszUrlPath:       [^]u16,
 	dwUrlPathLength:   win.DWORD,
-	lpszExtraInfo:     ^u16,
+	lpszExtraInfo:     [^]u16,
 	dwExtraInfoLength: win.DWORD,
 }
 
@@ -55,21 +60,38 @@ foreign winhttp {
 	WinHttpReadData :: proc(hRequest: HINTERNET, lpBuffer: rawptr, dwNumberOfBytesToRead: win.DWORD, lpdwNumberOfBytesRead: ^win.DWORD) -> win.BOOL ---
 }
 
+Request_Query_Param :: struct {
+	key, value: string,
+}
+
 Response :: struct {
 	status: i32,
 	data:   []u8,
 }
 
-get :: proc(url: string) -> Response {
+get :: proc(
+	scheme_hostname_path: string,
+	opts: []Request_Query_Param,
+	allocator := context.allocator,
+) -> Response {
+	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
+
 	result := Response{0, nil}
 
-	url_wstring := win.utf8_to_wstring(url)
-
 	urlComp := URL_COMPONENTS{}
-	hostName := make([]u16, 256)
-	urlPath := make([]u16, 1024)
-	defer delete(hostName)
-	defer delete(urlPath)
+	hostName := make([]u16, 256, context.temp_allocator)
+	urlPath := make([]u16, 1024, context.temp_allocator)
+
+	// WinHttp has facilities for escaping (ICU_ESCAPE), but sadly without support for >1 "extra infos".
+	// That is, parameters containing an "&" or "?" need be escaped manually first anyways..!
+	urlExtras: strings.Builder
+	strings.builder_init(&urlExtras, context.temp_allocator)
+	for opt, i in opts {
+		strings.write_rune(&urlExtras, i > 0 ? '&' : '?')
+		strings.write_string(&urlExtras, opt.key)
+		strings.write_rune(&urlExtras, '=')
+		strings.write_string(&urlExtras, net.percent_encode(opt.value, context.temp_allocator))
+	}
 
 	urlComp.dwStructSize = win.DWORD(size_of(URL_COMPONENTS))
 	urlComp.lpszHostName = raw_data(hostName)
@@ -77,11 +99,22 @@ get :: proc(url: string) -> Response {
 	urlComp.lpszUrlPath = raw_data(urlPath)
 	urlComp.dwUrlPathLength = win.DWORD(len(urlPath))
 
+	url_wstring := win.utf8_to_wstring(scheme_hostname_path)
 	if !WinHttpCrackUrl(url_wstring, 0, 0, &urlComp) {
 		return result
 	}
 
-	userAgent := win.utf8_to_wstring("github.com/mfbulut/MusicPlayer WinHTTP Client/1.0")
+	// This is a no-op for requests without query parameters.
+	lpszUrlPathWithParams := slice.concatenate(
+		[][]u16 {
+			urlComp.lpszUrlPath[:urlComp.dwUrlPathLength],
+			win.utf8_to_utf16(strings.to_string(urlExtras)),
+			win.L("")[:1],
+		},
+		context.temp_allocator,
+	)
+
+	userAgent := win.L("github.com/mfbulut/MusicPlayer WinHTTP Client/1.0")
 
 	hSession := WinHttpOpen(userAgent, WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, nil, nil, 0)
 	if hSession == nil do return result
@@ -92,12 +125,12 @@ get :: proc(url: string) -> Response {
 	defer WinHttpCloseHandle(hConnect)
 
 	flags := urlComp.nScheme == INTERNET_SCHEME_HTTPS ? WINHTTP_FLAG_SECURE : 0
-	verb := win.utf8_to_wstring("GET")
+	verb := win.L("GET")
 
 	hRequest := WinHttpOpenRequest(
 		hConnect,
 		verb,
-		urlComp.lpszUrlPath,
+		raw_data(lpszUrlPathWithParams),
 		nil,
 		nil,
 		nil,
@@ -129,37 +162,20 @@ get :: proc(url: string) -> Response {
 	result.status = i32(status_code)
 
 	totalSize: win.DWORD = 0
-	buffer: []u8
+	buffer := make([dynamic]byte, context.allocator)
 
 	for {
 		chunkSize: win.DWORD = 0
-		if !WinHttpQueryDataAvailable(hRequest, &chunkSize) || chunkSize == 0 {
-			break
-		}
+		WinHttpQueryDataAvailable(hRequest, &chunkSize) or_break
+		(chunkSize > 0) or_break
 
-		old_len := len(buffer)
-		new_buffer := make([]u8, old_len + int(chunkSize))
-		copy(new_buffer[:old_len], buffer)
-		delete(buffer)
-		buffer = new_buffer
+		resize(&buffer, totalSize + chunkSize)
 
 		bytesRead: win.DWORD = 0
-		if !WinHttpReadData(hRequest, raw_data(buffer[old_len:]), chunkSize, &bytesRead) {
-			delete(buffer)
-			buffer = nil
-			break
-		}
-
-		if int(bytesRead) < int(chunkSize) {
-			final_buffer := make([]u8, old_len + int(bytesRead))
-			copy(final_buffer, buffer[:old_len + int(bytesRead)])
-			delete(buffer)
-			buffer = final_buffer
-		}
-
+		WinHttpReadData(hRequest, raw_data(buffer[totalSize:]), chunkSize, &bytesRead) or_break
 		totalSize += bytesRead
 	}
 
-	result.data = buffer
+	result.data = slice.clone(buffer[:totalSize], allocator)
 	return result
 }


### PR DESCRIPTION
Refactored http (use std library for escaping, simpler buffer allocation logic). Some tracks had an '&' or '?' in the title which required special handling.

Unfortunately the API can return decimal track durations(!), which breaks unmarshalling, so `LyricsResponse.duration` is an `f32` now... 

I have a ton of metadata-less songs in an `00 - Artist - Title` format, I've added a splitter to make lyric requests appropriately. Though I've found loads more variations on this format... handling every case could be future work. 