### PR TITLE
Add GitHub Actions workflow for Windows build and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Build and Release
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build_release:
+    runs-on: windows-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Odin
+        uses: laytan/setup-odin@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup MSVC tools
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Build with Odin
+        shell: cmd
+        run: |
+          odin build src -out:music.exe -o:speed -resource:src/assets/resource.rc -subsystem:windows
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: music-windows-${{ github.ref_name }}
+          path: music.exe
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload executable to Release
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: music.exe
+          asset_name: MusicPlayer-${{ github.ref_name }}.exe
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
## This PR adds a GitHub Actions workflow that triggers on tag push. It builds the project using Odin and MSVC on Windows, then creates a GitHub release and uploads the built executable as an artifact.

For example:

Add a new tag in your local

```bash
   git tag v0.2.4
```

and push to Github.

```bash
   git push origin v0.2.4
```